### PR TITLE
Don't pause community contributions in new tracks

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -80,6 +80,7 @@ system("rm -rf %s" % File.join(dir, "Gemfile.lock"))
 system("rm -rf %s" % File.join(dir, ".ruby-version"))
 system("rm -rf %s" % File.join(dir, "bin/bootstrap"))
 system("rm -rf %s" % File.join(dir, ".github/ISSUE_TEMPLATE.md"))
+system("rm -rf %s" % File.join(dir, ".github/workflows/pause-community-contributions.yml"))
 system("mv %s/TRACK_README.md %s/README.md" % [dir, dir])
 
 f = File.join(dir, 'LICENSE')


### PR DESCRIPTION
New tracks can choose to pause contributions if they want,
but it probably doesn't make sense to do so.

Let's not pause them by default when bootstrapping.
